### PR TITLE
Use correct var when adding torrent

### DIFF
--- a/lib/Transmission/Client.pm
+++ b/lib/Transmission/Client.pm
@@ -316,11 +316,11 @@ sub add {
         return;
     }
     elsif($args{'filename'}) {
-        return $self->rpc('torrent-add', @_);
+        return $self->rpc('torrent-add', %args);
     }
     elsif($args{'metainfo'}) {
         $args{'metainfo'} = encode_base64($args{'metainfo'});
-        return $self->rpc('torrent-add', @_);
+        return $self->rpc('torrent-add', %args);
     }
     else {
         $self->error("Need either filename or metainfo argument");


### PR DESCRIPTION
Hi,

Transmission::Client::add makes efforts to base64 encode the metainfo parameter, but doesn't pass the encoded data to the rpc method. I opened a ticket on rt.cpan.org as well, but I haven't heard anything about it, and after that I found the module here on github. I'm making a pull request for you convenience, don't mean to stress you ;-)...

Thanks,
/Olof
