### PR TITLE
Skip (un)wanted-files requests if list is empty

### DIFF
--- a/lib/Transmission/Torrent.pm
+++ b/lib/Transmission/Torrent.pm
@@ -632,6 +632,9 @@ sub write_wanted {
     }
 
     for my $key (qw/wanted unwanted/) {
+        # Transmission interpret an empty list to mean all files
+        next unless @{$wanted{$key}};
+
         $self->client->rpc('torrent-set' =>
             ids => [ $self->id ], "files-$key" => $wanted{$key}
         ) or return;


### PR DESCRIPTION
Hi,

If i set all files in a torrent to wanted through Transmission::Client, transmission
sets all to unwanted. This is because Transmission::Client sends a empty list
for the unwanted files.

https://trac.transmissionbt.com/browser/trunk/extras/rpc-spec.txt#L121

> Just as an empty "ids" value is shorthand for "all ids", using an
> empty array for "files-wanted", "files-unwanted", "priority-high",
> "priority-low", or "priority-normal" is shorthand for saying "all
> files"."
