### PR TITLE
simplify the stats role

### DIFF
--- a/lib/Transmission/Stats.pm
+++ b/lib/Transmission/Stats.pm
@@ -42,67 +42,63 @@ with 'Transmission::AttributeRole';
 
 =cut
 
-BEGIN {
-    my %both = (
-        activeTorrentCount  => number,
-        downloadSpeed       => number,
-        pausedTorrentCount  => number,
-        torrentCount        => number,
-        uploadSpeed         => number,
+my %both = (
+    activeTorrentCount  => number,
+    downloadSpeed       => number,
+    pausedTorrentCount  => number,
+    torrentCount        => number,
+    uploadSpeed         => number,
+);
+
+for my $camel (keys %both) {
+    (my $name = $camel) =~ s/([A-Z]+)/{ "_" .lc($1) }/ge;
+
+    has $name => (
+        is      => 'ro',
+        isa     => $both{$camel},
+        coerce  => 1,
+        writer  => "_set_$name",
+        clearer => "clear_$name",
+        lazy    => 1,
+        default => sub {
+            my $self = shift;
+            my $val = delete $self->_tmp_store->{$name};
+
+            return $val if defined $val;
+
+            $self->_clear_tmp_store;
+            return delete $self->_tmp_store->{$name};
+        },
     );
+}
+
+has _tmp_store => (
+    is      => 'ro',
+    isa     => 'HashRef',
+    lazy    => 1,
+    builder => 'read_all',
+    clearer => '_clear_tmp_store',
+);
+
+sub read_all {
+    my $self = shift;
+    my $lazy = $self->lazy_write;
+    my(%res, $rpc);
+
+    $rpc = $self->client->rpc('session-stats') or return;
+
+    $self->lazy_write(1);
 
     for my $camel (keys %both) {
-        (my $name = $camel) =~ s/([A-Z]+)/{ "_" .lc($1) }/ge;
-        __PACKAGE__->meta->add_attribute($name => (
-            is => 'ro',
-            isa => $both{$camel},
-            coerce => 1,
-            writer => "_set_$name",
-            clearer => "clear_$name",
-            lazy => 1,
-            default => sub {
-                my $self = shift;
-                my $val = delete $self->_tmp_store->{$name};
-
-                if(defined $val) {
-                    return $val;
-                }
-                else {
-                    $self->_clear_tmp_store;
-                    return delete $self->_tmp_store->{$name};
-                }
-            },
-        ));
+        my $name = __PACKAGE__->_camel2Normal($camel);
+        my $writer = "_set_$name";
+        $res{$name} = $rpc->{$camel};
+        $self->$writer($rpc->{$camel});
     }
 
-    __PACKAGE__->meta->add_attribute(_tmp_store => (
-        is => 'ro',
-        isa => 'HashRef',
-        lazy => 1,
-        builder => 'read_all',
-        clearer => '_clear_tmp_store',
-    ));
+    $self->lazy_write($lazy);
 
-    __PACKAGE__->meta->add_method(read_all => sub {
-        my $self = shift;
-        my $lazy = $self->lazy_write;
-        my(%res, $rpc);
-
-        $rpc = $self->client->rpc('session-stats') or return;
-
-        $self->lazy_write(1);
-
-        for my $camel (keys %both) {
-            my $name = __PACKAGE__->_camel2Normal($camel);
-            my $writer = "_set_$name";
-            $res{$name} = $rpc->{$camel};
-            $self->$writer($rpc->{$camel});
-        }
-
-        $self->lazy_write($lazy);
-
-        return \%res;
-    });
+    return \%res;
 }
 
 =head1 LICENSE

--- a/t/transmission-stats.t
+++ b/t/transmission-stats.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Transmission::Stats;
+
+%::test_stats = (
+    activeTorrentCount => 1,
+    downloadSpeed      => 2,
+    pausedTorrentCount => 3,
+    torrentCount       => 4,
+);
+
+{ 
+    package Mock::Client;
+    use Moose;
+    sub rpc { \%::test_stats }
+}
+
+my $stats = Transmission::Stats->new( client => Mock::Client->new );
+
+can_ok $stats, qw/ _tmp_store read_all /;
+
+subtest 'read_all' => sub {
+    $stats->read_all;
+
+    for ( keys %::test_stats ) {
+        my $method = Transmission::Stats->_camel2Normal($_);
+        is $stats->$method => $::test_stats{$_};
+    }
+};

--- a/t/transmission-stats.t
+++ b/t/transmission-stats.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 3;
 
 use Transmission::Stats;
 
@@ -22,7 +22,10 @@ my $stats = Transmission::Stats->new( client => Mock::Client->new );
 
 can_ok $stats, qw/ _tmp_store read_all /;
 
-subtest 'read_all' => sub {
+for my $method ( qw/  read_all _tmp_store / ) {
+subtest $method => sub {
+    my $stats = Transmission::Stats->new( client => Mock::Client->new );
+
     $stats->read_all;
 
     for ( keys %::test_stats ) {
@@ -30,3 +33,4 @@ subtest 'read_all' => sub {
         is $stats->$method => $::test_stats{$_};
     }
 };
+}


### PR DESCRIPTION
moved the definitions out of the BEGIN block, which didn't seem to be needed after all.